### PR TITLE
Require timerep < 2.0, due to interface change

### DIFF
--- a/google-drive.cabal
+++ b/google-drive.cabal
@@ -37,7 +37,7 @@ Library
                       , resourcet
                       , text
                       , time
-                      , timerep
+                      , timerep         < 2.0
                       , unordered-containers
 
 Test-Suite spec


### PR DESCRIPTION
I just encountered a build failure because I happened to have `timerep` 2.0.0 installed. Unfortunately, it looks like supporting both interfaces would need conditional compilation. But nothing I'm building with requires 2.0.0 yet, so the upper bound did the trick.
